### PR TITLE
[MOYEO-75] 내용 인증 api 연동

### DIFF
--- a/src/app/challenge-detail/[id]/page.tsx
+++ b/src/app/challenge-detail/[id]/page.tsx
@@ -181,7 +181,7 @@ export default function ChallengeDetail() {
     const diff = Math.ceil(
       (startDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
     );
-    return diff > 0 ? `D-${diff}` : "진행중";
+    return diff > 0 ? `D-${diff}` : `D+${Math.abs(diff + 1)}`;
   };
 
   const handleJoinChallenge = async () => {

--- a/src/app/challenge-detail/[id]/page.tsx
+++ b/src/app/challenge-detail/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { loadTossPayments } from "@tosspayments/payment-sdk";
 import { ConfirmModal } from "components/Modal";
 import { ChevronRight, ChevronDown, Plus, X } from "lucide-react";
+import Challenge from "app/challenge/page";
 
 type Challenge = {
   challengeId: string;
@@ -23,6 +24,7 @@ type Challenge = {
     end?: string;
   };
   rule: number;
+  participating: boolean;
 };
 
 type ChallengeLog = {
@@ -360,140 +362,144 @@ export default function ChallengeDetail() {
         </div>
       </div>
       {/* 내 인증 영역 */}
-      <div className="p-6 border-b border-gray-200">
-        {keywordsError ? (
-          <div>
-            {/* 아직 키워드 입력 X → 목표 설정 UI */}
-            <button
-              className="flex w-full items-center justify-between"
-              onClick={() => setIsExpanded(!isExpanded)}
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-2xl">✏️</span>
-                <p className="font-bold">오늘의 목표를 설정하세요</p>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-500">
-                  목표 설정 시간 : {challenge.option.start} ~{" "}
-                  {challenge.option.end}
-                </span>
-                {isExpanded ? <ChevronDown /> : <ChevronRight />}
-              </div>
-            </button>
-            {/* 키워드 입력 섹션 - 슬라이드 애니메이션 */}
-            <div
-              className={`overflow-hidden transition-all duration-300 ease-in-out ${
-                isExpanded ? "max-h-96 opacity-100 mt-4" : "max-h-0 opacity-0"
-              }`}
-            >
-              <div className="bg-gray-50 rounded-lg p-4">
-                <h3 className="font-semibold text-gray-800 mb-3">
-                  목표 키워드 입력 (3개 필수)
-                </h3>
-
-                {/* 현재 입력된 키워드들 */}
-                {keywords.length > 0 && (
-                  <div className="flex flex-wrap gap-2 mb-3">
-                    {keywords.map((keyword, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-purple-100 text-purple-800 text-sm font-medium"
-                      >
-                        # {keyword}
-                        <button
-                          onClick={() => handleRemoveKeyword(keyword)}
-                          className="hover:bg-purple-200 rounded-full p-0.5"
-                        >
-                          <X size={12} />
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                )}
-
-                {/* 키워드 입력 필드 */}
-                {keywords.length < 3 && (
-                  <div className="flex gap-2 mb-4">
-                    <input
-                      type="text"
-                      value={currentKeyword}
-                      onChange={(e) => setCurrentKeyword(e.target.value)}
-                      onKeyPress={handleKeyPress}
-                      placeholder="키워드를 입력하세요"
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                      maxLength={20}
-                    />
-                    <button
-                      onClick={handleAddKeyword}
-                      disabled={
-                        !currentKeyword.trim() ||
-                        keywords.includes(currentKeyword.trim())
-                      }
-                      className="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center gap-1"
-                    >
-                      <Plus size={16} />
-                      추가
-                    </button>
-                  </div>
-                )}
-
-                <div className="text-xs text-gray-500 mb-4">
-                  {keywords.length}/3개 입력됨
-                  {keywords.length < 3 && (
-                    <span className="text-red-500 font-medium ml-2">
-                      3개 모두 입력해주세요
-                    </span>
-                  )}
-                  {keywords.length === 3 && (
-                    <span className="text-green-600 font-medium ml-2">
-                      ✓ 완료
-                    </span>
-                  )}
-                </div>
-
-                {/* 저장 버튼 */}
-                <button
-                  onClick={handleSubmitKeywords}
-                  disabled={keywords.length !== 3}
-                  className="w-full py-3 bg-purple-500 text-white rounded-xl font-bold hover:bg-purple-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
-                >
-                  {keywords.length === 3
-                    ? "키워드 저장하기"
-                    : `키워드 ${3 - keywords.length}개 더 입력해주세요`}
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : myLog ? (
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <p className="font-bold">오늘의 목표 키워드</p>
-              <span className="text-xs text-red-500">
-                목표 키워드는 변경이 불가능합니다.
-              </span>
-            </div>
-            <div className="flex flex-wrap gap-2 mb-4">
-              {myLog.content?.keywords?.map((kw) => (
-                <span
-                  key={kw}
-                  className="px-3 py-1 rounded-full bg-gray-200 text-sm font-medium"
-                >
-                  #{kw}
-                </span>
-              ))}
-            </div>
-            {!showAuthPage && (
+      {challenge?.participating && (
+        <div className="p-6 border-b border-gray-200">
+          {keywordsError ? (
+            <div>
+              {/* 아직 키워드 입력 X → 목표 설정 UI */}
               <button
-                className="w-full py-3 bg-[#A3A0CA] rounded-xl font-bold text-white"
-                onClick={handleGoToAuth}
+                className="flex w-full items-center justify-between"
+                onClick={() => setIsExpanded(!isExpanded)}
               >
-                내용 인증 출석하러 가기 →
+                <div className="flex items-center gap-2">
+                  <span className="text-2xl">✏️</span>
+                  <p className="font-bold">오늘의 목표를 설정하세요</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-gray-500">
+                    목표 설정 시간 : {challenge.option.start} ~{" "}
+                    {challenge.option.end}
+                  </span>
+                  {isExpanded ? <ChevronDown /> : <ChevronRight />}
+                </div>
               </button>
-            )}
-          </div>
-        ) : null}
-      </div>
+              {/* 키워드 입력 섹션 - 슬라이드 애니메이션 */}
+              <div
+                className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                  isExpanded ? "max-h-96 opacity-100 mt-4" : "max-h-0 opacity-0"
+                }`}
+              >
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <h3 className="font-semibold text-gray-800 mb-3">
+                    목표 키워드 입력 (3개 필수)
+                  </h3>
 
+                  {/* 현재 입력된 키워드들 */}
+                  {keywords.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {keywords.map((keyword, index) => (
+                        <span
+                          key={index}
+                          className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-purple-100 text-purple-800 text-sm font-medium"
+                        >
+                          # {keyword}
+                          <button
+                            onClick={() => handleRemoveKeyword(keyword)}
+                            className="hover:bg-purple-200 rounded-full p-0.5"
+                          >
+                            <X size={12} />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* 키워드 입력 필드 */}
+                  {keywords.length < 3 && (
+                    <div className="flex gap-2 mb-4">
+                      <input
+                        type="text"
+                        value={currentKeyword}
+                        onChange={(e) => setCurrentKeyword(e.target.value)}
+                        onKeyPress={handleKeyPress}
+                        placeholder="키워드를 입력하세요"
+                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                        maxLength={20}
+                      />
+                      <button
+                        onClick={handleAddKeyword}
+                        disabled={
+                          !currentKeyword.trim() ||
+                          keywords.includes(currentKeyword.trim())
+                        }
+                        className="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center gap-1"
+                      >
+                        <Plus size={16} />
+                        추가
+                      </button>
+                    </div>
+                  )}
+
+                  <div className="text-xs text-gray-500 mb-4">
+                    {keywords.length}/3개 입력됨
+                    {keywords.length < 3 && (
+                      <span className="text-red-500 font-medium ml-2">
+                        3개 모두 입력해주세요
+                      </span>
+                    )}
+                    {keywords.length === 3 && (
+                      <span className="text-green-600 font-medium ml-2">
+                        ✓ 완료
+                      </span>
+                    )}
+                  </div>
+
+                  {/* 저장 버튼 */}
+                  <button
+                    onClick={handleSubmitKeywords}
+                    disabled={keywords.length !== 3}
+                    className="w-full py-3 bg-purple-500 text-white rounded-xl font-bold hover:bg-purple-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {keywords.length === 3
+                      ? "키워드 저장하기"
+                      : `키워드 ${3 - keywords.length}개 더 입력해주세요`}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : myLog ? (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <p className="font-bold">오늘의 목표 키워드</p>
+                <span className="text-xs text-red-500">
+                  목표 키워드는 변경이 불가능합니다.
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-2 mb-4">
+                {myLog.content?.keywords?.map((kw) => (
+                  <span
+                    key={kw}
+                    className="px-3 py-1 rounded-full bg-gray-200 text-sm font-medium"
+                  >
+                    #{kw}
+                  </span>
+                ))}
+              </div>
+              {!showAuthPage && (
+                <button
+                  className="w-full py-3 bg-[#A3A0CA] rounded-xl font-bold text-white disabled:cursor-not-allowed"
+                  onClick={handleGoToAuth}
+                  disabled={myLog?.status === "SUCCESS"}
+                >
+                  {myLog?.status !== "SUCCESS"
+                    ? "내용 인증 출석하러 가기 →"
+                    : "인증 완료"}
+                </button>
+              )}
+            </div>
+          ) : null}
+        </div>
+      )}
       {showAuthPage ? (
         <div className="flex-1 flex flex-col">
           {/* 내용 인증 섹션 */}
@@ -581,7 +587,7 @@ export default function ChallengeDetail() {
         </div>
       )}
       {/* 하단 버튼 */}
-      {!showAuthPage && (
+      {!challenge?.participating && (
         <div className="absolute bottom-5 left-6 right-6">
           <button
             onClick={handleJoinChallenge}


### PR DESCRIPTION
## 📝 PR 요약

#### 1. 챌린지 인증 내역 목록 조회
- `GET /v1/challenges/{challengeId}/logs` API 연동
- 챌린지 상세 화면 내 인증 로그 카드 UI에 반영

#### 2. 본인 챌린지 인증 단건 조회
- `GET /v1/challenges/{challengeId}/logs/me` API 연동
- 키워드 입력 여부에 따라 UI 분기 처리
  - 에러 응답 시 → "오늘의 목표를 설정하세요" 영역 표시
  - 정상 응답 시 → "오늘의 목표 키워드" + 키워드 리스트 표시

#### 3. 챌린지 인증 키워드 등록
- `POST /v1/challenges/{challengeId}/keywords` API 연동
- 키워드 3개 입력 후 서버에 저장
- 성공 시 본인 인증 로그 생성 → 이후 `/logs` 목록에서 조회 가능

#### 4. 챌린지 인증 내용 입력
- `PATCH /v1/challenges/{challengeId}/logs/{logId}/text` API 연동
- 본인이 등록한 키워드 로그(`logId`)에 대해 인증 텍스트 작성 기능 구현
- 성공 시 "인증 완료" 알림 및 인증 내역 목록 갱신

## ✅ 체크리스트

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 기타

## 📸 스크린샷 (선택)

### [목표 키워드 입력 란]

<img width="604" height="615" alt="스크린샷 2025-08-31 오후 6 38 13" src="https://github.com/user-attachments/assets/b7af98dd-8fa7-4288-bfad-52a5f5fdcdae" />

### [목표 키워드 3가지 모두 입력 후]
<img width="598" height="312" alt="스크린샷 2025-08-31 오후 6 38 25" src="https://github.com/user-attachments/assets/220a7ec4-de06-4637-b005-b1293535e943" />

### [챌린지 인증 내용 입력 ui]

<img width="609" height="850" alt="스크린샷 2025-08-31 오후 6 39 35" src="https://github.com/user-attachments/assets/2193b676-8820-4544-bd4f-12f2c9783205" />

### [ 챌린지 인증 후 ui]
<img width="383" height="945" alt="스크린샷 2025-08-31 오후 6 40 07" src="https://github.com/user-attachments/assets/334babd9-bb09-4391-8b75-2049a0eaf79a" />

## 📌 CodeRabbit 리뷰 가이드라인

> 아래 기준에 따라 리뷰해주세요. (작성자 및 리뷰어 모두 참고)

- 컴포넌트 이름은 PascalCase, 함수/변수는 camelCase를 사용합니다. (예: MyButton, handleClick)
- Tailwind CSS를 사용하고, inline style은 지양합니다.
- 재사용 가능한 UI는 components 디렉토리로 분리합니다.
- 훅은 항상 컴포넌트 최상단에서 호출합니다 (React Hooks 규칙).
- props와 state는 명확한 타입(TypeScript)을 지정합니다.
- any 타입 사용은 피하고, 명확한 타입 추론을 우선합니다.
- 조건부 렌더링에는 &&, ? : 등의 간결한 구문을 사용합니다.
- 복잡한 로직에는 주석 또는 분리된 함수로 명확하게 표현합니다.

## 📚 팀원들에게 요청사항
